### PR TITLE
feat: add more configuration and fix import path

### DIFF
--- a/example.py
+++ b/example.py
@@ -218,7 +218,7 @@ def main():
     print("🧪 vLLM Streaming Test Suite")
     print("=" * 50)
     print(f"🎯 Endpoint: {ENDPOINT_URL}")
-    print(f"🔑 API Key: {API_KEY[:10]}...")
+    print(f"🔑 API Key: {API_KEY[:10] if API_KEY else None}...")
     
     while True:
         print("\n" + "="*50)

--- a/example.py
+++ b/example.py
@@ -7,9 +7,9 @@ import sys
 # Configuration
 ENDPOINT_ID = os.getenv("ENDPOINT_ID", "your-endpoint-id")
 API_KEY = os.getenv("RUNPOD_API_KEY")
-ENDPOINT_URL = f"https://{ENDPOINT_ID}.api.runpod.ai"
+ENDPOINT_URL = os.getenv("ENDPOINT_URL", "http://localhost:8009") if os.getenv("ENDPOINT_URL") else f"https://{ENDPOINT_ID}.api.runpod.ai"
 
-if not API_KEY:
+if not API_KEY and not os.getenv("ENDPOINT_URL"):
     print("Error: Please set RUNPOD_API_KEY environment variable")
     sys.exit(1)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,6 @@
 from typing import List
 from transformers import AutoTokenizer
-from .models import ChatMessage, ErrorResponse
+from models import ChatMessage, ErrorResponse
 
 
 def get_tokenizer(model_name: str):


### PR DESCRIPTION
- feat(example script):
  - Add option to use ENDPOINT_URL to run locally before deploying to RunPod
  - Add validation to ensure API_KEY is only valid for RunPod
- feat:
  - Add more configuration options for VLLM deployment, such as SERVED_MODEL_NAME, etc.
- fix:
  - Change `.model` to `model` in the import path, since `.model` causes an error
